### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   build:
     if: github.event_name != 'release'


### PR DESCRIPTION
Potential fix for [https://github.com/omgitsjan/JanPetry.de/security/code-scanning/2](https://github.com/omgitsjan/JanPetry.de/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the root of the workflow file. Since the workflow only performs read operations (e.g., checking out code, setting up Node.js, installing dependencies, and building the project), we will set `contents: read` as the minimal required permission. This ensures that the workflow adheres to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
