### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -5,6 +5,9 @@ on:
     types:
       - created
 
+permissions:
+  contents: read
+
 jobs:
   build-and-push:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
Potential fix for [https://github.com/omgitsjan/JanPetry.de/security/code-scanning/1](https://github.com/omgitsjan/JanPetry.de/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root level of the workflow to explicitly define the minimal permissions required. Based on the workflow's operations, it only needs to read repository contents (`contents: read`) to check out the code. No write permissions are required for this workflow. This change will ensure that the workflow does not inadvertently gain unnecessary permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
